### PR TITLE
Change to web hash history

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
 import HistoryPage from "./pages/HistoryPage.vue";
 import HomePage from "./pages/HomePage.vue";
 import QueuePage from "./pages/QueuePage.vue";
-import { createWebHistory, createRouter } from "vue-router";
+import { createWebHashHistory, createRouter } from "vue-router";
 
 const routes = [
 	{ path: "/", component: HomePage },
@@ -10,6 +10,6 @@ const routes = [
 ];
 
 export const router = createRouter({
-	history: createWebHistory(),
+	history: createWebHashHistory(),
 	routes,
 });


### PR DESCRIPTION
Change from web history to web hash history in the router. This is to help prevent issues with the proxy not being able to find the routes created by the router.