### PR TITLE
Round the printer percentage

### DIFF
--- a/src/components/PrinterCard.vue
+++ b/src/components/PrinterCard.vue
@@ -122,7 +122,7 @@ const errorCount = computed(() => {
 			</div>
 			<div class="flex flex-row justify-between items-center gap-1 h-10" v-else>
 				<Badge variant="outline" v-if="showProgressPercentage"
-					>{{ printer.printerStatus.progress * 100 }}%</Badge
+					>{{ Math.round(printer.printerStatus.progress * 100) }}%</Badge
 				>
 				<Progress v-model="progress" class="w-full" />
 				<Badge variant="outline" v-if="showTimeRemaining">{{


### PR DESCRIPTION
Round the printer percentage to prevent displaying floating point errors